### PR TITLE
Add streaming UI components

### DIFF
--- a/docs/UI-UX-spec.md
+++ b/docs/UI-UX-spec.md
@@ -1,0 +1,42 @@
+# Streaming Crew UI/UX Spec
+
+This document outlines the design and interaction specification for a streaming crew portal. It summarizes the user scenarios, information architecture, components and interactions described in the "UI/UX 명세서" provided in the repository's conversation.
+
+## Overview
+
+The portal promotes live streams for a crew of seventeen creators. Fans can quickly see who is live, watch streams, or set notifications for offline members. The design emphasizes clarity, efficient use of space, and consistent Tailwind CSS classes.
+
+## Sections
+
+1. **Header** – logo, search, and profile/notification controls.
+2. **Highlight Section** – carousel that automatically cycles through prominent live streams with overlay details and call-to-action buttons.
+3. **Live Section** – grid or list of currently live streamers with thumbnails, viewer counts, and categories.
+4. **Offline Section** – scrollable list of offline members with a simple profile view and notification option.
+5. **Footer** – links to crew social accounts and legal pages.
+
+## Component Notes
+
+- **HighlightStreamCard** – shows a featured live stream with thumbnail background, viewer count, elapsed time, and follow/watch buttons. Includes optional chat summary on hover.
+- **LiveCard** – card used in the "Live Section" with a LIVE badge, viewer count, avatar, category, and truncated title.
+- **OfflineCard** – small card for offline members with a grayscale avatar and "알림 받기" button.
+
+## Interaction Highlights
+
+- Highlight carousel auto-advances every 10 seconds, pauses on hover, and supports swipe or keyboard navigation.
+- Live cards scale slightly on hover and open the respective stream page when clicked.
+- Offline cards open a modal for notification subscription.
+- All interactive elements include appropriate `aria-label`s and focus styles.
+
+## Responsive Behavior
+
+- **Desktop** – highlight height `60vh`, live cards displayed in four columns, offline cards show in a horizontal scroll.
+- **Tablet** – highlight height `40vh`, two or three live-card columns, offline cards scaled down.
+- **Mobile** – highlight height `25vh`, single-column list for live and offline sections.
+
+## Accessibility
+
+- Use `aria-live="polite"` for carousel announcements.
+- Provide keyboard access and focus rings for all interactive elements.
+- Ensure color contrast ratios meet WCAG AA standards.
+
+For full details and the original specification, refer to the project's conversation history.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,6 @@ const streamers = Array.from({ length: 17 }).map((_, i) => ({
 }))
 
 const sorted = [...streamers].sort((a, b) => b.viewers - a.viewers)
-}))
 
 export default function Home() {
   return (
@@ -30,6 +29,19 @@ export default function Home() {
             <div className="snap-x flex space-x-4 overflow-x-auto py-2 px-4 md:px-6 h-[320px] scrollbar-hide">
               {sorted.map((s) => (
                 <LiveStreamerCard
+                  key={s.id}
+                  id={s.id}
+                  streamerName={s.name}
+                  thumbnailUrl={s.thumbnail}
+                  profileUrl={s.profile}
+                  category={s.category}
+                  viewers={s.viewers}
+                  isLive={s.isLive}
+                  title={s.title}
+                />
+              ))}
+            </div>
+
             <h2 className="text-2xl font-bold mb-6">주요 스트리머</h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
               {streamers.map((s) => (

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -1,0 +1,75 @@
+import HighlightStreamCard from '@/components/HighlightStreamCard'
+import LiveCard from '@/components/LiveCard'
+import OfflineCard from '@/components/OfflineCard'
+import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+
+const liveStreamers = Array.from({ length: 5 }).map((_, i) => ({
+  id: String(i + 1),
+  name: `스트리머 ${i + 1}`,
+  avatar: '/images/avatar-placeholder.png',
+  thumbnail: '/images/thumbnail-placeholder.png',
+  title: '재미있는 게임 방송 중',
+  category: '게임',
+  viewers: Math.floor(Math.random() * 1000) + 1,
+  elapsed: `${Math.floor(Math.random() * 50) + 1}분 경과`,
+}))
+
+const offlineStreamers = Array.from({ length: 8 }).map((_, i) => ({
+  id: String(i + 20),
+  name: `오프라인 ${i + 1}`,
+  avatar: '/images/avatar-placeholder.png',
+}))
+
+export default function PreviewPage() {
+  return (
+    <main className="min-h-screen bg-neutral-900 text-neutral-100">
+      <Header />
+      <div className="p-4 space-y-8">
+        <section className="relative h-[40vh] lg:h-[60vh]">
+          <HighlightStreamCard
+            id={liveStreamers[0].id}
+            name={liveStreamers[0].name}
+            avatarUrl={liveStreamers[0].avatar}
+            thumbnailUrl={liveStreamers[0].thumbnail}
+            title={liveStreamers[0].title}
+            category={liveStreamers[0].category}
+            viewerCount={liveStreamers[0].viewers}
+            elapsedTime={liveStreamers[0].elapsed}
+            chatSummary="오늘도 화이팅!"
+            isLive
+          />
+        </section>
+
+        <section>
+          <h3 className="text-2xl font-semibold mb-3">🔴 지금 라이브 중인 크루</h3>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            {liveStreamers.map((s) => (
+              <LiveCard
+                key={s.id}
+                id={s.id}
+                name={s.name}
+                avatarUrl={s.avatar}
+                thumbnailUrl={s.thumbnail}
+                title={s.title}
+                category={s.category}
+                viewerCount={s.viewers}
+                isLive
+              />
+            ))}
+          </div>
+        </section>
+
+        <section>
+          <h3 className="text-2xl font-semibold mb-3">🕑 지금 오프라인인 크루</h3>
+          <div className="flex space-x-4 overflow-x-auto scrollbar-hide">
+            {offlineStreamers.map((s) => (
+              <OfflineCard key={s.id} id={s.id} name={s.name} avatarUrl={s.avatar} />
+            ))}
+          </div>
+        </section>
+      </div>
+      <Footer />
+    </main>
+  )
+}

--- a/src/components/HighlightStreamCard.tsx
+++ b/src/components/HighlightStreamCard.tsx
@@ -1,0 +1,99 @@
+import React from 'react'
+import Image from 'next/image'
+
+interface HighlightStreamCardProps {
+  id: string
+  name: string
+  avatarUrl: string
+  thumbnailUrl: string
+  title: string
+  category: string
+  viewerCount: number
+  elapsedTime: string
+  chatSummary?: string
+  isLive: boolean
+}
+
+export default function HighlightStreamCard({
+  id,
+  name,
+  avatarUrl,
+  thumbnailUrl,
+  title,
+  category,
+  viewerCount,
+  elapsedTime,
+  chatSummary,
+  isLive,
+}: HighlightStreamCardProps) {
+  return (
+    <div className="relative w-full h-full group" role="group" aria-label={`${name} 스트림 하이라이트`}>
+      <Image
+        src={thumbnailUrl}
+        alt={`${name} 방송 썸네일`}
+        fill
+        className="object-cover"
+      />
+      <div className="absolute inset-0 bg-black bg-opacity-40" />
+      <div className="absolute bottom-4 left-4 right-4 text-neutral-100 space-y-2">
+        <div className="flex items-center space-x-2">
+          <Image
+            src={avatarUrl}
+            alt={`${name} 프로필`}
+            width={40}
+            height={40}
+            className="w-10 h-10 rounded-full object-cover bg-neutral-600"
+          />
+          <h2 className="text-xl lg:text-3xl font-semibold">{name}</h2>
+        </div>
+        <p className="text-lg lg:text-xl line-clamp-2">{title}</p>
+        <span className="text-neutral-300 text-sm">{category}</span>
+        <div className="flex items-center space-x-4 text-neutral-200">
+          {isLive && (
+            <span className="flex items-center space-x-1">
+              <svg
+                className="h-5 w-5 text-red-600 animate-pulse"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <circle cx="10" cy="10" r="5" />
+              </svg>
+              <span className="text-sm font-semibold">{viewerCount.toLocaleString()}명</span>
+            </span>
+          )}
+          <span className="flex items-center space-x-1">
+            <svg className="h-5 w-5 text-neutral-200" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path d="M10 2a8 8 0 100 16 8 8 0 000-16zm1 8H9V5h2v5z" />
+            </svg>
+            <span className="text-sm">{elapsedTime}</span>
+          </span>
+        </div>
+        <div className="flex space-x-3 pt-2">
+          {isLive ? (
+            <>
+              <a
+                href={`/stream/${id}`}
+                className="px-4 py-2 bg-primary-500 rounded-md text-neutral-100 font-medium hover:bg-primary-400 transition"
+              >
+                ▶ 시청하기
+              </a>
+              <button className="px-4 py-2 bg-neutral-700 rounded-md text-neutral-100 font-medium hover:bg-neutral-600 transition">
+                팔로우
+              </button>
+            </>
+          ) : (
+            <button className="px-4 py-2 bg-primary-500 rounded-md text-neutral-100 font-medium hover:bg-primary-400 transition">
+              ▶ 알림 설정
+            </button>
+          )}
+        </div>
+      </div>
+      {isLive && chatSummary && (
+        <div className="absolute top-4 right-4 bg-neutral-800 bg-opacity-80 p-2 rounded-md text-sm text-neutral-200 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+          {chatSummary}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/LiveCard.tsx
+++ b/src/components/LiveCard.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import Link from 'next/link'
+import Image from 'next/image'
+
+interface LiveCardProps {
+  id: string
+  name: string
+  avatarUrl: string
+  thumbnailUrl: string
+  title: string
+  category: string
+  viewerCount: number
+  isLive: boolean
+}
+
+export default function LiveCard({
+  id,
+  name,
+  avatarUrl,
+  thumbnailUrl,
+  title,
+  category,
+  viewerCount,
+  isLive,
+}: LiveCardProps) {
+  return (
+    <Link
+      href={`/stream/${id}`}
+      aria-label={`${name}님 실시간 방송 시청, 시청자 수 ${viewerCount}명, 카테고리 ${category}`}
+      className="bg-neutral-800 rounded-lg overflow-hidden group hover:shadow-lg transition-shadow duration-200 cursor-pointer"
+    >
+      <div className="relative w-full h-[140px] bg-neutral-700">
+        <Image src={thumbnailUrl} alt={`${name} 방송 썸네일`} fill className="object-cover" />
+        {isLive && (
+          <>
+            <span className="absolute top-2 left-2 bg-red-600 text-xs text-white px-1 py-0.5 rounded animate-pulse">
+              LIVE
+            </span>
+            <span className="absolute top-2 right-2 bg-neutral-900 bg-opacity-60 text-xs text-neutral-200 px-1 py-0.5 rounded">
+              {viewerCount.toLocaleString()}
+            </span>
+          </>
+        )}
+      </div>
+      <div className="p-3 space-y-1">
+        <div className="flex items-center space-x-2">
+          <Image src={avatarUrl} alt={`${name} 프로필`} width={32} height={32} className="w-8 h-8 rounded-full bg-neutral-600 object-cover" />
+          <span className="text-neutral-100 text-sm font-medium truncate">{name}</span>
+        </div>
+        <p className="text-neutral-400 text-xs">{category}</p>
+        <p className="text-neutral-200 text-sm leading-snug line-clamp-2" title={title}>
+          {title}
+        </p>
+      </div>
+    </Link>
+  )
+}

--- a/src/components/OfflineCard.tsx
+++ b/src/components/OfflineCard.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import Image from 'next/image'
+
+interface OfflineCardProps {
+  name: string
+  avatarUrl: string
+  nextSchedule?: string
+}
+
+export default function OfflineCard({ name, avatarUrl, nextSchedule }: OfflineCardProps) {
+  return (
+    <div
+      className="flex-shrink-0 w-[100px] bg-neutral-700 rounded-lg p-3 flex flex-col items-center space-y-2 group hover:bg-neutral-600 transition"
+      aria-label={`${name}님은 현재 오프라인, 다음 방송 ${nextSchedule ?? '미정'}`}
+    >
+      <div className="relative">
+        <Image src={avatarUrl} alt={`${name} 프로필`} width={64} height={64} className="w-16 h-16 rounded-full object-cover grayscale" />
+        <span className="absolute bottom-0 right-0 bg-neutral-900 bg-opacity-70 text-neutral-400 text-xs px-1 py-0.5 rounded">
+          OFFLINE
+        </span>
+      </div>
+      <span className="text-neutral-100 text-sm font-medium truncate">{name}</span>
+      <button className="bg-primary-500 text-white text-xs px-2 py-1 rounded-sm hover:bg-primary-400 transition">
+        알림 받기
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- implement `HighlightStreamCard`, `LiveCard`, and `OfflineCard` components
- add preview page using new components
- fix home page markup

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842d6e7991883288459faff12dcb7e1