### PR TITLE
Integrate demo into Next.js and extend design system

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -18,6 +18,7 @@
   --color-neutral-50:  #f5f5f5;  /* 아주 희미한 배경 에센스 (거의 쓰지 않음) */
 
   --color-primary-500: #8257e5; /* 보라 계열 톤, 강조할 때만 사용 */
+  --color-secondary-500: #4f46e5; /* 보라 계열 보조 색상 */
 
   --spacing-1:  0.25rem;   /* p-1 */
   --spacing-2:  0.5rem;    /* p-2 */

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,51 +1,91 @@
 import Header from '@/components/Header'
-import Sidebar from '@/components/Sidebar'
-import LiveStreamerCard from '@/components/LiveStreamerCard'
-import StreamCard from '@/components/StreamCard'
 import Footer from '@/components/Footer'
+import HighlightStreamCard from '@/components/HighlightStreamCard'
+import LiveCard from '@/components/LiveCard'
+import OfflineCard from '@/components/OfflineCard'
 
-const streamers = Array.from({ length: 17 }).map((_, i) => ({
+const liveStreamers = Array.from({ length: 4 }).map((_, i) => ({
   id: String(i + 1),
   name: `스트리머 ${i + 1}`,
+  avatar: '/images/avatar-placeholder.png',
   thumbnail: '/images/thumbnail-placeholder.png',
-  profile: '/images/avatar-placeholder.png',
-  category: '게임',
-  viewers: Math.floor(Math.random() * 10000) + 1,
-  isLive: true,
   title: '재미있는 게임 방송 중',
+  category: '게임',
+  viewers: Math.floor(Math.random() * 1000) + 1,
+  elapsed: `${Math.floor(Math.random() * 50) + 1}분 경과`,
 }))
 
-const sorted = [...streamers].sort((a, b) => b.viewers - a.viewers)
+const offlineStreamers = Array.from({ length: 6 }).map((_, i) => ({
+  id: String(i + 20),
+  name: `오프라인 ${i + 1}`,
+  avatar: '/images/avatar-placeholder.png',
+}))
 
 export default function Home() {
   return (
     <main className="min-h-screen bg-neutral-900 text-neutral-100">
       <Header />
-      <div className="flex">
-        <Sidebar />
-        <div className="flex-1 p-6 space-y-8">
-          <section>
-            <h2 className="text-2xl font-semibold text-center mb-4">🎥 LIVE NOW</h2>
-            <div className="snap-x flex space-x-4 overflow-x-auto py-2 px-4 md:px-6 h-[320px] scrollbar-hide">
-            <h2 className="text-2xl font-bold mb-6">주요 스트리머</h2>
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-              {streamers.map((s) => (
-                <StreamCard
-                  key={s.id}
-                  id={s.id}
-                  streamerName={s.name}
-                  thumbnailUrl={s.thumbnail}
-                  profileUrl={s.profile}
-                  category={s.category}
-                  viewers={s.viewers}
-                  isLive={s.isLive}
-                  title={s.title}
-                />
-              ))}
-            </div>
-            </div>
-          </section>
-        </div>
+      <div className="p-4 space-y-8">
+        <section className="relative h-[40vh] lg:h-[60vh]">
+          <HighlightStreamCard
+            id={liveStreamers[0].id}
+            name={liveStreamers[0].name}
+            avatarUrl={liveStreamers[0].avatar}
+            thumbnailUrl={liveStreamers[0].thumbnail}
+            title={liveStreamers[0].title}
+            category={liveStreamers[0].category}
+            viewerCount={liveStreamers[0].viewers}
+            elapsedTime={liveStreamers[0].elapsed}
+            chatSummary="오늘도 화이팅!"
+            isLive
+          />
+        </section>
+
+        <section>
+          <div className="flex items-center justify-between mb-3">
+            <h3 className="text-2xl font-semibold">
+              🔴 지금 라이브 중인 크루{' '}
+              <span className="text-neutral-400 text-lg">(4/17)</span>
+            </h3>
+            <button className="text-primary-500 hover:underline text-sm">
+              더보기 &gt;
+            </button>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            {liveStreamers.map((s) => (
+              <LiveCard
+                key={s.id}
+                id={s.id}
+                name={s.name}
+                avatarUrl={s.avatar}
+                thumbnailUrl={s.thumbnail}
+                title={s.title}
+                category={s.category}
+                viewerCount={s.viewers}
+                isLive
+              />
+            ))}
+          </div>
+          <div className="mt-4 text-center lg:hidden">
+            <button className="px-4 py-2 bg-secondary-500 text-neutral-100 font-medium rounded-md hover:bg-secondary-500/90 transition">
+              더 많은 라이브 보기
+            </button>
+          </div>
+        </section>
+
+        <section>
+          <h3 className="text-2xl font-semibold mb-3">🕑 지금 오프라인인 크루</h3>
+          <div className="flex space-x-4 overflow-x-auto scrollbar-hide">
+            {offlineStreamers.map((s) => (
+              <OfflineCard key={s.id} name={s.name} avatarUrl={s.avatar} />
+            ))}
+          </div>
+          <div className="mt-3 text-center lg:hidden">
+            <button className="px-4 py-2 border border-neutral-600 rounded-md text-neutral-300 font-medium hover:border-neutral-500 hover:text-neutral-200 transition">
+              + 더보기
+            </button>
+          </div>
+        </section>
       </div>
       <Footer />
     </main>

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -64,7 +64,7 @@ export default function PreviewPage() {
           <h3 className="text-2xl font-semibold mb-3">🕑 지금 오프라인인 크루</h3>
           <div className="flex space-x-4 overflow-x-auto scrollbar-hide">
             {offlineStreamers.map((s) => (
-              <OfflineCard key={s.id} id={s.id} name={s.name} avatarUrl={s.avatar} />
+              <OfflineCard key={s.id} name={s.name} avatarUrl={s.avatar} />
             ))}
           </div>
         </section>

--- a/src/app/stream/[id]/page.tsx
+++ b/src/app/stream/[id]/page.tsx
@@ -1,6 +1,6 @@
 
-export default function StreamPage({ params }: { params: { id: string } }) {
-  const { id } = params
+export default async function StreamPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
   return (
     <main className="min-h-screen bg-neutral-900 text-neutral-100 p-6 space-y-6">
       <h1 className="text-2xl font-bold">스트리머 {id}</h1>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,6 +19,7 @@ const config: Config = {
         'neutral-100': 'var(--color-neutral-100)',
         'neutral-50': 'var(--color-neutral-50)',
         'primary-500': 'var(--color-primary-500)',
+        'secondary-500': 'var(--color-secondary-500)',
       },
       spacing: {
         1: 'var(--spacing-1)',


### PR DESCRIPTION
## Summary
- drop standalone HTML mockup
- add secondary color token in Tailwind design system
- rebuild homepage layout using project components
- fix preview and dynamic page types

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842f74f78548328bb2d971d9726a0c9