### PR TITLE
Add dev-only design system shortcut

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import DevDesignSystemLink from "@/components/DevDesignSystemLink";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -15,6 +16,7 @@ export default function RootLayout({
     <html lang="en">
       <body className="antialiased">
         {children}
+        <DevDesignSystemLink />
       </body>
     </html>
   );

--- a/src/components/DevDesignSystemLink.tsx
+++ b/src/components/DevDesignSystemLink.tsx
@@ -1,0 +1,17 @@
+'use client'
+import Link from 'next/link'
+
+export default function DevDesignSystemLink() {
+  if (process.env.NODE_ENV !== 'development') {
+    return null
+  }
+
+  return (
+    <Link
+      href="/design-system"
+      className="fixed bottom-4 right-4 z-50 px-3 py-2 rounded-md bg-primary-500 text-neutral-100 text-sm shadow-lg hover:bg-primary-400"
+    >
+      Design System
+    </Link>
+  )
+}


### PR DESCRIPTION
## Summary
- add a `DevDesignSystemLink` component that shows a fixed link to `/design-system` when running in development mode
- include the dev link in the root layout

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684565eea2f08328974c109963eff97c