### PR TITLE
Implement streaming hub page

### DIFF
--- a/src/app/streaminghub/page.tsx
+++ b/src/app/streaminghub/page.tsx
@@ -1,0 +1,90 @@
+'use client'
+import { useRef } from 'react'
+import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import LiveCard from '@/components/LiveCard'
+import OfflineCard from '@/components/OfflineCard'
+import MainCarousel, { StreamerInfo } from '@/components/MainCarousel'
+import LiveSummaryItem from '@/components/LiveSummaryItem'
+
+const liveStreamers: StreamerInfo[] = Array.from({ length: 5 }).map((_, i) => ({
+  id: String(i + 1),
+  name: `스트리머 ${i + 1}`,
+  avatar: '/next.svg',
+  thumbnail: '/vercel.svg',
+  title: '재미있는 게임 방송 중',
+  category: '게임',
+  viewers: Math.floor(Math.random() * 1000) + 1,
+  elapsed: `${Math.floor(Math.random() * 50) + 1}분 경과`,
+}))
+
+const offlineStreamers = Array.from({ length: 12 }).map((_, i) => ({
+  id: String(i + 20),
+  name: `오프라인 ${i + 1}`,
+  avatar: '/next.svg',
+}))
+
+export default function StreamingHubPage() {
+  const cardRefs = useRef<(HTMLDivElement | null)[]>([])
+  const scrollToCard = (idx: number) => {
+    cardRefs.current[idx]?.scrollIntoView({ behavior: 'smooth', inline: 'start' })
+  }
+
+  return (
+    <main className="min-h-screen bg-neutral-900 text-neutral-100">
+      <Header />
+      <div className="p-4 space-y-8">
+        <MainCarousel streamers={liveStreamers} />
+
+        <section>
+          <div className="flex overflow-x-auto space-x-3 scrollbar-hide py-2">
+            {liveStreamers.map((s, idx) => (
+              <LiveSummaryItem
+                key={s.id}
+                name={s.name}
+                avatarUrl={s.avatar}
+                viewers={s.viewers}
+                onClick={() => scrollToCard(idx)}
+              />
+            ))}
+          </div>
+        </section>
+
+        <section>
+          <div className="flex overflow-x-auto space-x-4 snap-x pb-4 scrollbar-hide">
+            {liveStreamers.map((s, idx) => (
+              <div
+                key={s.id}
+                ref={(el) => {
+                  cardRefs.current[idx] = el
+                }}
+                className="flex-shrink-0 w-[220px] snap-start"
+              >
+                <LiveCard
+                  id={s.id}
+                  name={s.name}
+                  avatarUrl={s.avatar}
+                  thumbnailUrl={s.thumbnail}
+                  title={s.title}
+                  category={s.category}
+                  viewerCount={s.viewers}
+                  isLive
+                />
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section>
+          <h3 className="text-2xl font-semibold mb-3">🕑 지금 오프라인인 크루</h3>
+          <div className="flex space-x-4 overflow-x-auto scrollbar-hide pb-3">
+            {offlineStreamers.map((s) => (
+              <OfflineCard key={s.id} name={s.name} avatarUrl={s.avatar} />
+            ))}
+          </div>
+        </section>
+      </div>
+      <Footer />
+    </main>
+  )
+}

--- a/src/components/LiveSummaryItem.tsx
+++ b/src/components/LiveSummaryItem.tsx
@@ -1,0 +1,23 @@
+'use client'
+import Image from 'next/image'
+
+interface LiveSummaryItemProps {
+  name: string
+  avatarUrl: string
+  viewers: number
+  onClick?: () => void
+}
+
+export default function LiveSummaryItem({ name, avatarUrl, viewers, onClick }: LiveSummaryItemProps) {
+  return (
+    <button
+      onClick={onClick}
+      className="flex-shrink-0 w-24 p-2 bg-neutral-800 rounded-md flex flex-col items-center space-y-1 hover:bg-neutral-700 transition"
+      aria-label={`${name} 방송으로 이동`}
+    >
+      <Image src={avatarUrl} alt={`${name} 프로필`} width={48} height={48} className="rounded-full object-cover" />
+      <span className="text-neutral-100 text-xs truncate">{name}</span>
+      <span className="text-red-500 text-xs font-medium">LIVE {viewers}</span>
+    </button>
+  )
+}

--- a/src/components/MainCarousel.tsx
+++ b/src/components/MainCarousel.tsx
@@ -1,0 +1,60 @@
+'use client'
+import { useState, useEffect, useCallback } from 'react'
+import HighlightStreamCard from './HighlightStreamCard'
+
+export interface StreamerInfo {
+  id: string
+  name: string
+  avatar: string
+  thumbnail: string
+  title: string
+  category: string
+  viewers: number
+  elapsed: string
+}
+
+export default function MainCarousel({ streamers }: { streamers: StreamerInfo[] }) {
+  const [index, setIndex] = useState(0)
+  const nextSlide = useCallback(() => {
+    setIndex((i) => (i + 1) % streamers.length)
+  }, [streamers.length])
+  const prev = useCallback(() => {
+    setIndex((i) => (i - 1 + streamers.length) % streamers.length)
+  }, [streamers.length])
+
+  useEffect(() => {
+    const id = setInterval(nextSlide, 10000)
+    return () => clearInterval(id)
+  }, [nextSlide])
+
+  const current = streamers[index]
+  return (
+    <div className="relative h-[40vh] lg:h-[60vh]">
+      <HighlightStreamCard
+        id={current.id}
+        name={current.name}
+        avatarUrl={current.avatar}
+        thumbnailUrl={current.thumbnail}
+        title={current.title}
+        category={current.category}
+        viewerCount={current.viewers}
+        elapsedTime={current.elapsed}
+        isLive
+      />
+      <button
+        onClick={prev}
+        className="absolute top-1/2 left-4 -translate-y-1/2 bg-neutral-800 bg-opacity-60 text-neutral-100 p-2 rounded-full hover:bg-opacity-80"
+        aria-label="이전 방송"
+      >
+        ‹
+      </button>
+      <button
+        onClick={nextSlide}
+        className="absolute top-1/2 right-4 -translate-y-1/2 bg-neutral-800 bg-opacity-60 text-neutral-100 p-2 rounded-full hover:bg-opacity-80"
+        aria-label="다음 방송"
+      >
+        ›
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add StreamingHub page to showcase highlight carousel, live summaries, live card list, and offline section
- support interactive carousel component for main stream
- add live summary item component

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846fab9d4588328a7afd084e45fbc81