### PR TITLE
Update sample image paths

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,8 +7,8 @@ import OfflineCard from '@/components/OfflineCard'
 const liveStreamers = Array.from({ length: 4 }).map((_, i) => ({
   id: String(i + 1),
   name: `스트리머 ${i + 1}`,
-  avatar: '/images/avatar-placeholder.png',
-  thumbnail: '/images/thumbnail-placeholder.png',
+  avatar: '/profile_shample.png',
+  thumbnail: '/thumbnail_sample.avif',
   title: '재미있는 게임 방송 중',
   category: '게임',
   viewers: Math.floor(Math.random() * 1000) + 1,
@@ -18,7 +18,7 @@ const liveStreamers = Array.from({ length: 4 }).map((_, i) => ({
 const offlineStreamers = Array.from({ length: 6 }).map((_, i) => ({
   id: String(i + 20),
   name: `오프라인 ${i + 1}`,
-  avatar: '/images/avatar-placeholder.png',
+  avatar: '/profile_shample.png',
 }))
 
 export default function Home() {

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -7,8 +7,8 @@ import Footer from '@/components/Footer'
 const liveStreamers = Array.from({ length: 5 }).map((_, i) => ({
   id: String(i + 1),
   name: `스트리머 ${i + 1}`,
-  avatar: '/images/avatar-placeholder.png',
-  thumbnail: '/images/thumbnail-placeholder.png',
+  avatar: '/profile_shample.png',
+  thumbnail: '/thumbnail_sample.avif',
   title: '재미있는 게임 방송 중',
   category: '게임',
   viewers: Math.floor(Math.random() * 1000) + 1,
@@ -18,7 +18,7 @@ const liveStreamers = Array.from({ length: 5 }).map((_, i) => ({
 const offlineStreamers = Array.from({ length: 8 }).map((_, i) => ({
   id: String(i + 20),
   name: `오프라인 ${i + 1}`,
-  avatar: '/images/avatar-placeholder.png',
+  avatar: '/profile_shample.png',
 }))
 
 export default function PreviewPage() {

--- a/src/app/streaminghub/page.tsx
+++ b/src/app/streaminghub/page.tsx
@@ -10,8 +10,8 @@ import LiveSummaryItem from '@/components/LiveSummaryItem'
 const liveStreamers: StreamerInfo[] = Array.from({ length: 5 }).map((_, i) => ({
   id: String(i + 1),
   name: `스트리머 ${i + 1}`,
-  avatar: '/next.svg',
-  thumbnail: '/vercel.svg',
+  avatar: '/profile_shample.png',
+  thumbnail: '/thumbnail_sample.avif',
   title: '재미있는 게임 방송 중',
   category: '게임',
   viewers: Math.floor(Math.random() * 1000) + 1,
@@ -21,7 +21,7 @@ const liveStreamers: StreamerInfo[] = Array.from({ length: 5 }).map((_, i) => ({
 const offlineStreamers = Array.from({ length: 12 }).map((_, i) => ({
   id: String(i + 20),
   name: `오프라인 ${i + 1}`,
-  avatar: '/next.svg',
+  avatar: '/profile_shample.png',
 }))
 
 export default function StreamingHubPage() {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -58,7 +58,7 @@ export default function Header() {
             aria-label="프로필"
           >
             <Image
-              src="/images/avatar-placeholder.png"
+              src="/profile_shample.png"
               alt="프로필"
               width={32}
               height={32}


### PR DESCRIPTION
## Summary
- use sample profile and thumbnail images across pages
- update header profile icon to sample image

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68496df154d4832896327de92d2ee29f