### PR TITLE
Implement responsive highlight card

### DIFF
--- a/src/components/HighlightStreamCard.tsx
+++ b/src/components/HighlightStreamCard.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+'use client'
+import React, { useState, useEffect, useRef, CSSProperties } from 'react'
 import Image from 'next/image'
 
 interface HighlightStreamCardProps {
@@ -26,8 +27,36 @@ export default function HighlightStreamCard({
   chatSummary,
   isLive,
 }: HighlightStreamCardProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [size, setSize] = useState<CSSProperties>({})
+
+  useEffect(() => {
+    const updateSize = () => {
+      const el = containerRef.current?.parentElement
+      if (!el) return
+      const parentWidth = el.clientWidth
+      const parentHeight = el.clientHeight
+      let height = Math.min(parentHeight, window.innerHeight * 0.6)
+      let width = height * (16 / 9)
+      if (width > parentWidth) {
+        width = parentWidth
+        height = width * (9 / 16)
+      }
+      setSize({ width, height })
+    }
+    updateSize()
+    window.addEventListener('resize', updateSize)
+    return () => window.removeEventListener('resize', updateSize)
+  }, [])
+
   return (
-    <div className="relative w-full h-full group" role="group" aria-label={`${name} 스트림 하이라이트`}>
+    <div
+      ref={containerRef}
+      style={size}
+      className="relative mx-auto group overflow-hidden"
+      role="group"
+      aria-label={`${name} 스트림 하이라이트`}
+    >
       <Image
         src={thumbnailUrl}
         alt={`${name} 방송 썸네일`}

--- a/src/components/LiveCard.tsx
+++ b/src/components/LiveCard.tsx
@@ -29,8 +29,13 @@ export default function LiveCard({
       aria-label={`${name}님 실시간 방송 시청, 시청자 수 ${viewerCount}명, 카테고리 ${category}`}
       className="bg-neutral-800 rounded-lg overflow-hidden group hover:shadow-lg transition-shadow duration-200 cursor-pointer"
     >
-      <div className="relative w-full h-[140px] bg-neutral-700">
-        <Image src={thumbnailUrl} alt={`${name} 방송 썸네일`} fill className="object-cover" />
+      <div className="relative w-full aspect-video bg-neutral-700">
+        <Image
+          src={thumbnailUrl}
+          alt={`${name} 방송 썸네일`}
+          fill
+          className="object-cover"
+        />
         {isLive && (
           <>
             <span className="absolute top-2 left-2 bg-red-600 text-xs text-white px-1 py-0.5 rounded animate-pulse">


### PR DESCRIPTION
## Summary
- implement 16:9 enforcement for highlight card
- use resize logic so the card never exceeds 60vh
- keep LiveCard thumbnails in a 16:9 ratio

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ced17b3083288f8e94db0c778015